### PR TITLE
Added Loggly webhook

### DIFF
--- a/hooks/loggly/README.md
+++ b/hooks/loggly/README.md
@@ -1,0 +1,6 @@
+### Loggly
+
+Sends a log event to your Loggly log.
+
+* Create a new HTTP/S input on Loggly. Set the log type to JSON.
+* Get your Service Key from Loggly as detailed in the [API Event Submission](http://loggly.com/support/advanced/api-event-submission/) page.

--- a/hooks/loggly/index.js
+++ b/hooks/loggly/index.js
@@ -1,0 +1,29 @@
+var request = require("request");
+
+exports.serviceName = "Loggly";
+
+exports.author = {
+	name: "Tal Bereznitskey",
+	email: "berzniz@gmail.com",
+	github: "berzniz",
+	twitter: "ketacode"
+};
+
+exports.onError = function(error, settings, done) {
+	// API call docs: http://loggly.com/support/advanced/api-event-submission/
+
+	request({
+		url: "https://logs.loggly.com/inputs/" + settings.serviceKey,
+		headers: {
+			"Content-Type": "application/json",
+			"User-Agent": "Errorception Notifications"
+		},
+		method: "post",
+		body: JSON.stringify({
+			description: "\"" + error.message + "\" caught by Errorception. See " + error.webUrl + " for details",
+			details: error
+		}),
+
+		timeout: 10000
+	}, done);
+};


### PR DESCRIPTION
I added a webhook for [Loggly](http://www.loggly.com). Loggly is a cloud-based log management service. My company, Bizzabo, is using it to log events from our distributed servers.

There is only one required settings for it (a service key as detailed here: [API Event Submission](http://loggly.com/support/advanced/api-event-submission/)).

I tested it with my company's Loggly account and it works like a charm.

The ability to create a webhook from Errorception to Loggly is great for us and I hope it will also help other Errorception users.

I'll be glad to provide more information and help if needed.
