### PR TITLE
Add support for Google Hangouts Chat

### DIFF
--- a/hooks/google-hangouts/README.md
+++ b/hooks/google-hangouts/README.md
@@ -2,5 +2,19 @@
 
 Sends message to the configured Google Hangouts Room.
 
+#### Setup
+
 - Provide the WebHook URL available in Room settings.
-- If you want the messages to appear in the same thread, add a `&threadKey=errorception` to the Webhook URL.
+
+#### How to get WebHook URL
+
+- Open room to which you want to send messages.
+- Click on the room name in top bar and select 'Configure webhooks'.
+- Click on 'Add WebHook' and fill name (e.g. Errorception Bot).
+- Click on 'Save' and copy 'WebHook URL'.
+
+Details: [Setting up an incoming webhook](https://developers.google.com/hangouts/chat/how-tos/webhooks)
+
+#### Grouping messages in the same thread
+
+- If you want the messages to appear in the same thread instead of creating new threads everytime, you can add `&threadKey=errorception` to end of the Webhook URL.

--- a/hooks/google-hangouts/README.md
+++ b/hooks/google-hangouts/README.md
@@ -1,0 +1,6 @@
+### Google Hangouts Chat
+
+Sends message to the configured Google Hangouts Room.
+
+- Provide the WebHook URL available in Room settings.
+- If you want the messages to appear in the same thread, add a `&threadKey=errorception` to the Webhook URL.

--- a/hooks/google-hangouts/index.js
+++ b/hooks/google-hangouts/index.js
@@ -1,0 +1,53 @@
+var request = require("request");
+
+exports.serviceName = "Google Hangouts Chat";
+
+exports.author = {
+  name: "Md Faizaan",
+  email: "aulisius7@gmail.com",
+  github: "aulisius",
+  twitter: "aulisius_"
+};
+
+exports.onError = function(error, settings, done) {
+  let message = {
+    cards: [
+      {
+        header: { title: "Errorception Bot", subtitle: "errorception.com" },
+        sections: [
+          {
+            header: "Error Details",
+            widgets: [
+              { keyValue: { topLabel: "Page", content: error.page } },
+              { keyValue: { topLabel: "Message", content: error.message } }
+            ]
+          },
+          {
+            widgets: [
+              {
+                buttons: [
+                  {
+                    textButton: {
+                      text: "VIEW ERROR",
+                      onClick: { openLink: { url: error.webUrl } }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  };
+  request(
+    {
+      url: settings.url,
+      headers: { "Content-Type": "application/json" },
+      method: "POST",
+      body: JSON.stringify(message),
+      timeout: 10000
+    },
+    done
+  );
+};


### PR DESCRIPTION
Hi!

This PR is for integrating Google Hangouts Rooms.

[API Documentation for integrating with Hangouts Chat](https://developers.google.com/hangouts/chat/reference)

Below is how the error shows up in a Room.

I've used the Card format which I believe will help this integration to be extensible in the future.

<img width="332" alt="Screen Shot 2020-03-23 at 9 12 46 PM" src="https://user-images.githubusercontent.com/6629172/77334626-145f8300-6d4b-11ea-8f30-9d15acd4fa6f.png">

The `View Error` button is a link to the `webUrl`.

As for the integration settings, we require only the WebHooks URL so I believe it's UI will look similar to that of WebHooks.

@rakeshpai thoughts?